### PR TITLE
Fix five_zhao_paipan KeyError on large numbers

### DIFF
--- a/kinwuzhao.py
+++ b/kinwuzhao.py
@@ -88,7 +88,7 @@ def five_zhao_paipan(day_gan):
 
     for idx, (gong, label) in enumerate(zip(gongs, labels)):
         num = nums[idx]
-        element = num_to_element[num]
+        element = num_to_element[(num - 1) % 5 + 1]
 
         # 六親判斷
         relation_code = config.multi_key_dict_get(config.wuxing_relation_2, my_element + element)


### PR DESCRIPTION
## Summary
- ensure five_zhao_paipan can map numbers beyond 5 to five elements

## Testing
- `python -m py_compile kinwuzhao.py app.py config.py jieqi.py`

------
https://chatgpt.com/codex/tasks/task_e_685e5d8d86508320bfd34ca970c90833