### PR TITLE
Fix bidict version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pendulum==2.1.2
-bidict==0.20.1
+bidict==0.23.1
 streamlit==1.45.0
 streamlit-screen-stats==0.0.82
 streamlit-local-storage==0.0.25


### PR DESCRIPTION
## Summary
- pin `bidict` at a valid release

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864b3d679988320a6f49d18676920e3